### PR TITLE
小米手环9支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@
 ### 已验证设备
 **蓝牙广播发送端**
 1. Garmin Enduro 2（佳明手表，蓝牙广播推送）
+2. Xiaomi Smart Band 9（小米手环9，更新到1.3.206+固件后在 设置-心率广播 手动开启）
 
 **蓝牙广播接收端**
 1. iPhone 15 Pro（无证书可自行签名）
@@ -114,8 +115,6 @@
 3. MacBook Pro M5（macOS Tahoe 26.1）
 4. Windows（B450I GAMING PLUS AC 主板，自带蓝牙）
 
-### 已知不支持/限制
-- **Mi Smart Band 系列**：设备通常不公开标准 BLE Heart Rate Service，且心率读取依赖厂商私有协议与鉴权（如配对密钥/握手），因此无法通过通用 BLE 心率特征直接接入本项目。
 
 ## 🛡️ 平台支持与权限
 - **Android**：需要 BLE 扫描/连接权限（Android 12+ 无需定位，11 及以下需定位权限）。Android 13+ 若想显示常驻通知卡片，请允许通知权限。

--- a/lib/heart_rate_manager.dart
+++ b/lib/heart_rate_manager.dart
@@ -708,6 +708,7 @@ class HeartRateManager extends ChangeNotifier {
         name.contains('coros') ||
         name.contains('suunto') ||
         name.contains('fitbit') ||
+        name.contains('mi smart band') ||
         name.contains('xiaomi') ||
         name.contains('watch');
 
@@ -753,7 +754,6 @@ class HeartRateManager extends ChangeNotifier {
     'watch',
     'hrm',
     'heart',
-    'tracker',
     'fit',
     'wear',
     'miband',

--- a/lib/heart_rate_manager.dart
+++ b/lib/heart_rate_manager.dart
@@ -708,6 +708,7 @@ class HeartRateManager extends ChangeNotifier {
         name.contains('coros') ||
         name.contains('suunto') ||
         name.contains('fitbit') ||
+        name.contains('xiaomi') ||
         name.contains('watch');
 
     return hasHeartRateService || hasHeartRateServiceData || likelyHrWearable;
@@ -747,6 +748,23 @@ class HeartRateManager extends ChangeNotifier {
       'desktop',
     ];
 
+  const wearableKeywords = [
+    'band',
+    'watch',
+    'hrm',
+    'heart',
+    'tracker',
+    'fit',
+    'wear',
+    'miband',
+    'mi band',
+    'smart band',
+    'smartband'
+  ];
+    
+  if (wearableKeywords.any(name.contains)) {
+    return false;
+  }
     return phoneKeywords.any(name.contains) || pcKeywords.any(name.contains);
   }
 


### PR DESCRIPTION
小米手环9在更新固件1.3.206+后发送的心率广播是标准的BLE HR了
<img width="416" height="382" alt="Snipaste_2025-12-22_22-04-35" src="https://github.com/user-attachments/assets/0ac1241a-c8ff-44b7-8ca5-98ec05264da9" />
